### PR TITLE
feat: Add subtle grid pattern to blog background

### DIFF
--- a/grid.css
+++ b/grid.css
@@ -1,0 +1,7 @@
+.subtle-grid-pattern {
+  background-color: #ffffff;
+  background-image:
+    repeating-linear-gradient(to right, rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 20px),
+    repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 20px);
+  background-size: 20px 20px;
+}

--- a/src/app/blog/layout.js
+++ b/src/app/blog/layout.js
@@ -3,7 +3,7 @@ import "prismjs/themes/prism-tomorrow.css";
 
 function BlogLayout({ children }) {
   return (
-    <div className="h-full grid grid-rows-[3rem_1fr] overflow-y-auto">
+    <div className="h-full grid grid-rows-[3rem_1fr] overflow-y-auto subtle-grid-pattern">
       <HeadNav />
       {children}
     </div>

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -41,3 +41,11 @@ h6 {
   height: auto;
   clip: auto;
 }
+
+.subtle-grid-pattern {
+  background-color: #ffffff;
+  background-image:
+    repeating-linear-gradient(to right, rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 20px),
+    repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 20px);
+  background-size: 20px 20px;
+}


### PR DESCRIPTION
Adds a repeating linear gradient grid pattern to the background of the blog pages. The pattern consists of light gray lines on a white background, with a 20px grid spacing, providing a subtle visual texture.

The CSS for the pattern is added to `src/app/global.css` and applied to the main layout element in `src/app/blog/layout.js`.